### PR TITLE
Fix iterators hal

### DIFF
--- a/TransmartRestApiGrailsPlugin.groovy
+++ b/TransmartRestApiGrailsPlugin.groovy
@@ -23,9 +23,12 @@
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+
+import org.grails.plugins.web.rest.render.DefaultRendererRegistry
 import org.springframework.aop.scope.ScopedProxyFactoryBean
 import org.springframework.stereotype.Component
 import org.transmartproject.rest.marshallers.MarshallersRegistrar
+import org.transmartproject.rest.marshallers.TransmartRendererRegistry
 
 class TransmartRestApiGrailsPlugin {
     def version = "1.2.2-SNAPSHOT"
@@ -65,6 +68,11 @@ class TransmartRestApiGrailsPlugin {
 
         marshallersRegistrar(MarshallersRegistrar) {
             packageName = 'org.transmartproject.rest.marshallers'
+        }
+
+        // override bean
+        rendererRegistry(TransmartRendererRegistry) { bean ->
+            modelSuffix = application.flatConfig.get('grails.scaffolding.templates.domainSuffix') ?: ''
         }
     }
 

--- a/grails-app/controllers/org/transmartproject/rest/ConceptController.groovy
+++ b/grails-app/controllers/org/transmartproject/rest/ConceptController.groovy
@@ -26,8 +26,9 @@
 package org.transmartproject.rest
 
 import grails.rest.Link
+import groovy.transform.TypeChecked
 import org.transmartproject.core.ontology.ConceptsResource
-import org.transmartproject.rest.marshallers.CollectionResponseWrapper
+import org.transmartproject.rest.marshallers.ContainerResponseWrapper
 import org.transmartproject.rest.marshallers.OntologyTermWrapper
 import org.transmartproject.rest.ontology.OntologyTermCategory
 
@@ -64,9 +65,9 @@ class ConceptController {
      * @param source
      * @return CollectionResponseWrapper so we can provide a proper HAL response
      */
-    def wrapConcepts(Object source) {
-        new CollectionResponseWrapper(
-                collection: source,
+    private ContainerResponseWrapper wrapConcepts(List<OntologyTermWrapper> source) {
+        new ContainerResponseWrapper(
+                container: source,
                 componentType: OntologyTermWrapper,
                 links: [
                         new Link(grails.rest.render.util.AbstractLinkingRenderer.RELATIONSHIP_SELF,

--- a/grails-app/controllers/org/transmartproject/rest/HighDimController.groovy
+++ b/grails-app/controllers/org/transmartproject/rest/HighDimController.groovy
@@ -34,7 +34,7 @@ import org.transmartproject.core.dataquery.assay.Assay
 import org.transmartproject.core.dataquery.highdim.HighDimensionDataTypeResource
 import org.transmartproject.core.exceptions.InvalidArgumentsException
 import org.transmartproject.core.ontology.OntologyTerm
-import org.transmartproject.rest.marshallers.CollectionResponseWrapper
+import org.transmartproject.rest.marshallers.ContainerResponseWrapper
 import org.transmartproject.rest.marshallers.HighDimSummary
 import org.transmartproject.rest.marshallers.HighDimSummarySerializationHelper
 import org.transmartproject.rest.marshallers.OntologyTermWrapper
@@ -153,8 +153,8 @@ class HighDimController {
 
     private def wrapList(List source, String selfLink) {
 
-        new CollectionResponseWrapper(
-                collection: source,
+        new ContainerResponseWrapper(
+                container: source,
                 componentType: HighDimSummary,
                 links: [
                         new Link(grails.rest.render.util.AbstractLinkingRenderer.RELATIONSHIP_SELF, selfLink),

--- a/grails-app/controllers/org/transmartproject/rest/ObservationController.groovy
+++ b/grails-app/controllers/org/transmartproject/rest/ObservationController.groovy
@@ -38,6 +38,7 @@ import org.transmartproject.core.ontology.Study
 import org.transmartproject.core.querytool.QueriesResource
 import org.transmartproject.core.querytool.QueryResult
 import org.transmartproject.rest.marshallers.ObservationWrapper
+import org.transmartproject.rest.misc.ComponentIndicatingContainer
 import org.transmartproject.rest.ontology.OntologyTermCategory
 
 import static org.transmartproject.core.dataquery.clinical.ClinicalVariable.NORMALIZED_LEAFS_VARIABLE
@@ -228,7 +229,10 @@ class ObservationController {
     }
 
     static class TabularResultObservationsIterator
-            extends AbstractIterator<ObservationWrapper> {
+            extends AbstractIterator<ObservationWrapper>
+            implements ComponentIndicatingContainer {
+
+        final Class<?> componentType = ObservationWrapper
 
         Iterator<PatientRow> originalRowIterator
         List<ClinicalVariable> clinicalVariables

--- a/grails-app/controllers/org/transmartproject/rest/SubjectController.groovy
+++ b/grails-app/controllers/org/transmartproject/rest/SubjectController.groovy
@@ -31,7 +31,7 @@ import org.transmartproject.core.dataquery.clinical.PatientsResource
 import org.transmartproject.core.exceptions.NoSuchResourceException
 import org.transmartproject.core.ontology.ConceptsResource
 import org.transmartproject.core.ontology.OntologyTerm
-import org.transmartproject.rest.marshallers.CollectionResponseWrapper
+import org.transmartproject.rest.marshallers.ContainerResponseWrapper
 import org.transmartproject.rest.ontology.OntologyTermCategory
 
 class SubjectController {
@@ -97,8 +97,8 @@ class SubjectController {
 
     private def wrapSubjects(Object source, String selfLink) {
 
-        new CollectionResponseWrapper(
-                collection: source,
+        new ContainerResponseWrapper(
+                container: source,
                 componentType: Patient,
                 links: [
                         new Link(grails.rest.render.util.AbstractLinkingRenderer.RELATIONSHIP_SELF,

--- a/src/groovy/org/transmartproject/rest/marshallers/ContainerResponseWrapper.groovy
+++ b/src/groovy/org/transmartproject/rest/marshallers/ContainerResponseWrapper.groovy
@@ -28,12 +28,12 @@ package org.transmartproject.rest.marshallers
 import grails.rest.Link
 
 // wrapper for collections of core-api helper so we can target a marshaller to them
-class CollectionResponseWrapper {
+class ContainerResponseWrapper {
 
     List<Link> links = []
 
     Class componentType
 
-    Collection collection
+    Object container // in the general sense. Can be Iterator
 
 }

--- a/src/groovy/org/transmartproject/rest/marshallers/ContainerResponseWrapperSerializationHelper.groovy
+++ b/src/groovy/org/transmartproject/rest/marshallers/ContainerResponseWrapperSerializationHelper.groovy
@@ -29,12 +29,12 @@ import grails.rest.Link
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.ApplicationContext
 
-class CollectionResponseWrapperSerializationHelper implements HalOrJsonSerializationHelper<CollectionResponseWrapper> {
+class ContainerResponseWrapperSerializationHelper implements HalOrJsonSerializationHelper<ContainerResponseWrapper> {
 
     @Autowired
     ApplicationContext ctx
 
-    final Class<CollectionResponseWrapper> targetType = CollectionResponseWrapper
+    final Class<ContainerResponseWrapper> targetType = ContainerResponseWrapper
 
     final String collectionName = 'collection'
 
@@ -46,20 +46,20 @@ class CollectionResponseWrapperSerializationHelper implements HalOrJsonSerializa
     }
 
     @Override
-    Collection<Link> getLinks(CollectionResponseWrapper object) {
+    Collection<Link> getLinks(ContainerResponseWrapper object) {
         object.links
     }
 
     @Override
-    Map<String, Object> convertToMap(CollectionResponseWrapper object) {
+    Map<String, Object> convertToMap(ContainerResponseWrapper object) {
         String key = getKeyForObjectType(object.componentType)
         [
-                (key): object.collection
+                (key): object.container
         ]
     }
 
     @Override
-    Set<String> getEmbeddedEntities(CollectionResponseWrapper object) {
+    Set<String> getEmbeddedEntities(ContainerResponseWrapper object) {
         [getKeyForObjectType(object.componentType)] as Set
     }
 

--- a/src/groovy/org/transmartproject/rest/marshallers/HalOrJsonRenderer.groovy
+++ b/src/groovy/org/transmartproject/rest/marshallers/HalOrJsonRenderer.groovy
@@ -86,6 +86,7 @@ class HalOrJsonRenderer<T> extends AbstractIncludeExcludeRenderer<T> implements 
     void afterPropertiesSet() throws Exception {
         rendererRegistry.addRenderer this
         rendererRegistry.addRenderer new HalOrJsonCollectionRenderer(this, Collection)
+        rendererRegistry.addRenderer new HalOrJsonCollectionRenderer(this, Iterator)
     }
 
     @Override

--- a/src/groovy/org/transmartproject/rest/marshallers/HalOrJsonRenderer.groovy
+++ b/src/groovy/org/transmartproject/rest/marshallers/HalOrJsonRenderer.groovy
@@ -49,30 +49,32 @@ class HalOrJsonRenderer<T> extends AbstractIncludeExcludeRenderer<T> implements 
     @Autowired
     RendererRegistry rendererRegistry
 
-    static class HalOrJsonCollectionRenderer<T> extends AbstractRenderer<Collection>
-            implements ContainerRenderer<Collection, T> {
+    static class HalOrJsonCollectionRenderer<C, T> extends AbstractRenderer<C>
+            implements ContainerRenderer<C, T> {
 
         final Class<T> componentType
 
-        final Class<Collection> targetType = Collection
+        final Class<C> targetType
 
         final AbstractIncludeExcludeRenderer<T> renderer
 
-        HalOrJsonCollectionRenderer(AbstractIncludeExcludeRenderer<T> renderer) {
-            super(Collection, renderer.mimeTypes)
+        HalOrJsonCollectionRenderer(AbstractIncludeExcludeRenderer<T> renderer,
+                                    Class<C> containerType) {
+            super(containerType, renderer.mimeTypes)
             componentType = renderer.getTargetType()
             this.renderer = renderer
+            this.targetType = containerType
         }
 
         @Override
-        void render(Collection object, RenderContext context) {
+        void render(C object, RenderContext context) {
             def mimeType = context.acceptMimeType ?: mimeTypes[0]
             def newObject = object
 
             if (mimeType.name == MimeType.HAL_JSON.name) {
-                newObject = new CollectionResponseWrapper(
+                newObject = new ContainerResponseWrapper(
                         componentType: componentType,
-                        collection: object)
+                        container: object)
             }
 
             renderer.render newObject, context
@@ -83,7 +85,7 @@ class HalOrJsonRenderer<T> extends AbstractIncludeExcludeRenderer<T> implements 
     @Override
     void afterPropertiesSet() throws Exception {
         rendererRegistry.addRenderer this
-        rendererRegistry.addRenderer new HalOrJsonCollectionRenderer(this)
+        rendererRegistry.addRenderer new HalOrJsonCollectionRenderer(this, Collection)
     }
 
     @Override

--- a/src/groovy/org/transmartproject/rest/marshallers/MarshallersRegistrar.groovy
+++ b/src/groovy/org/transmartproject/rest/marshallers/MarshallersRegistrar.groovy
@@ -32,7 +32,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.config.BeanDefinition
 import org.springframework.beans.factory.config.BeanDefinitionHolder
 import org.springframework.beans.factory.support.BeanDefinitionBuilder
-import org.springframework.beans.factory.support.BeanDefinitionRegistry
 import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider
 import org.springframework.core.type.filter.AssignableTypeFilter
@@ -46,7 +45,8 @@ import static org.springframework.beans.factory.support.BeanDefinitionReaderUtil
  * JSON Marshaller so that {@link grails.converters.JSON} knows what to do
  * when it find <code>foo as JSON</code>.
  *
- * Also register the {@link IteratorMarshaller}.
+ * Also register the {@link IteratorMarshaller} so that
+ * {@link grails.converters.JSON} knows how to handle them.
  */
 @Log4j
 public class MarshallersRegistrar implements FactoryBean {

--- a/src/groovy/org/transmartproject/rest/marshallers/MarshallersRegistrar.groovy
+++ b/src/groovy/org/transmartproject/rest/marshallers/MarshallersRegistrar.groovy
@@ -68,7 +68,6 @@ public class MarshallersRegistrar implements FactoryBean {
         Set<BeanDefinition> serializationHelpers =
                 scanner.findCandidateComponents packageName
 
-        BeanDefinitionRegistry registry = ctx
         for (BeanDefinition helperDef: serializationHelpers) {
             log.debug "Processing serialization helper ${helperDef.beanClassName}"
 

--- a/src/groovy/org/transmartproject/rest/marshallers/OntologyTermSerializationHelper.groovy
+++ b/src/groovy/org/transmartproject/rest/marshallers/OntologyTermSerializationHelper.groovy
@@ -44,7 +44,6 @@ class OntologyTermSerializationHelper implements HalOrJsonSerializationHelper<On
 
     @Override
     Collection<Link> getLinks(OntologyTermWrapper obj) {
-        OntologyTerm term = obj.delegate
         String url = studyLoadingServiceProxy.getOntologyTermUrl(obj.delegate)
 
         Link datalink

--- a/src/groovy/org/transmartproject/rest/marshallers/TransmartRendererRegistry.groovy
+++ b/src/groovy/org/transmartproject/rest/marshallers/TransmartRendererRegistry.groovy
@@ -1,0 +1,21 @@
+package org.transmartproject.rest.marshallers
+
+import org.grails.plugins.web.rest.render.DefaultRendererRegistry
+import org.transmartproject.rest.misc.ComponentIndicatingContainer
+
+/**
+ * Customized the {@link DefaultRendererRegistry} by making it aware of the
+ * {@link ComponentIndicatingContainer}.
+ */
+class TransmartRendererRegistry extends DefaultRendererRegistry {
+
+    @Override
+    protected Class<? extends Object> getTargetClassForContainer(
+            Class containerClass, Object object) {
+        if (object instanceof ComponentIndicatingContainer) {
+            return object.componentType
+        }
+
+        super.getTargetClassForContainer(containerClass, object)
+    }
+}

--- a/src/groovy/org/transmartproject/rest/misc/ComponentIndicatingContainer.groovy
+++ b/src/groovy/org/transmartproject/rest/misc/ComponentIndicatingContainer.groovy
@@ -1,0 +1,18 @@
+package org.transmartproject.rest.misc
+
+import grails.rest.render.RendererRegistry
+import org.springframework.validation.BeanPropertyBindingResult
+
+/**
+ * Grails has two types of renderers: the regular ones and container renderers.
+ * For choosing the right container renderer, the {@link RendererRegistry} needs
+ * to know the type of objects inside the container.
+ *
+ * Indicates to the {@link RendererRegistry} the type of elements that this
+ * container has inside. This is generally not needed for {@link Iterable},
+ * {@link Map}, or {@link BeanPropertyBindingResult objects}, because the
+ * registry can already figure out the component type.
+ */
+interface ComponentIndicatingContainer {
+    Class<?> getComponentType()
+}

--- a/test/functional/org/transmartproject/rest/ObservationsResourceTests.groovy
+++ b/test/functional/org/transmartproject/rest/ObservationsResourceTests.groovy
@@ -29,6 +29,7 @@ import static org.codehaus.groovy.grails.web.json.JSONObject.NULL
 import static org.hamcrest.MatcherAssert.assertThat
 import static org.hamcrest.Matchers.*
 import static org.thehyve.commons.test.FastMatchers.listOfWithOrder
+import static org.thehyve.commons.test.FastMatchers.mapWith
 
 class ObservationsResourceTests extends ResourceTestCase {
 
@@ -166,5 +167,27 @@ class ObservationsResourceTests extends ResourceTestCase {
                 everyItem(allOf(
                         hasEntry('label', '\\foo\\study2\\sex\\'),
                         hasEntry(is('value'), is(NULL)))))
+    }
+
+    void testHalStandalone() {
+        getAsHal('/observations') {
+            patients = -101
+            concept_paths = '\\foo\\study1\\bar\\'
+        }
+
+        assertStatus 200
+
+        allOf(
+                hasLinks([:]),
+                hasEntry(
+                        is('_embedded'),
+                        hasEntry(
+                                is('observations'),
+                                contains(
+                                        mapWith(
+                                               label: '\\foo\\study1\\bar\\',
+                                                value: BigDecimal.valueOf(10.00000),
+                                        )))))
+
     }
 }

--- a/test/functional/org/transmartproject/rest/ResourceTestCase.groovy
+++ b/test/functional/org/transmartproject/rest/ResourceTestCase.groovy
@@ -47,7 +47,7 @@ abstract class ResourceTestCase extends APITestCase {
     }
 
     JSONElement getAsHal(String path, Closure paramSetup = null) {
-        doAsHal 'get', path
+        doAsHal 'get', path, paramSetup
     }
 
     JSONElement doAsHal(String method, String path, Closure paramSetup = null) {

--- a/test/integration/org/transmartproject/rest/highdim/HighDimDataServiceTests.groovy
+++ b/test/integration/org/transmartproject/rest/highdim/HighDimDataServiceTests.groovy
@@ -334,13 +334,15 @@ class HighDimResultRowsMatcher extends DiagnosingMatcher<HighDimResult> {
             Row gottenRow = result.rows[i]
 
             if (expectedRow instanceof BioMarkerDataRow) {
-                def matcher = hasProperty('bioMarker', is(expectedRow.bioMarker))
+                // protobuf representation of null bioMarker is empty string
+                def expectedBioMarker = expectedRow.bioMarker ?: ''
+                def matcher = hasProperty('bioMarker', is(expectedBioMarker))
                 if (!matcher.matches(gottenRow)) {
                     mismatchDescription
                             .appendText("on row $i expected ")
                             .appendDescriptionOf(matcher)
                             .appendText(' but: ')
-                    matcher.describeMismatch(result, mismatchDescription)
+                    matcher.describeMismatch(gottenRow, mismatchDescription)
                     return false
                 }
             }


### PR DESCRIPTION
Because the `/observations` call was directly returning an `Iterator`, Grails didn't know how to render this object as HAL. A previous commit had added `IteratorMarshaller`, but this handles the serialization at the level of `grails.converters.JSON`, which is what the Grails renderer eventually delegates to. This was enough for rendering the iterator as plain JSON (through some default Grails JSON renderer), but not as HAL. At the Grails renderer level, this would typically be handled by a `ContainerRenderer`. In our implementation, this is `org.transmartproject.rest.marshallers.HalOrJsonRenderer.HalOrJsonCollectionRenderer`.

After this changeset, container renderers for `Iterator`s are registered alongside the container renderers  for `Collection`s in `HalOrJsonRenderer::afterPropertiesSet()` (I use the plural here because the container renderers are specific for each container, component type combination). But this is not enough, because the default Grails `RendererRegistry` (`org.grails.plugins.web.rest.render.DefaultRendererRegistry`) won't be able to find these `Iterator` `ContainerRenderer`. The problem is that, the container renderers being specific to a container type and component type, the component type must be determined. `DefaultRendererRegistry` supports `Iterable` objects (it fetches an iterator and looks at the first element to determine the component type), but this not possible with `Iterator`s without causing unwanted side effects. Therefore, the `Iterator` object has to provide a component type for the registry. This is achieved by introducing the interface `ComponentIndicatingContainer` and overriding the default renderer registry with `TransmartRendererRegistry`, which knows about `ComponentIndicatingContainer`.