### PR TITLE
Include data type in concept response

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: groovy
+sudo: false
 
 jdk:
     - oraclejdk7

--- a/grails-app/controllers/org/transmartproject/rest/ConceptController.groovy
+++ b/grails-app/controllers/org/transmartproject/rest/ConceptController.groovy
@@ -44,7 +44,7 @@ class ConceptController {
     */
     def index() {
         def concepts = studyLoadingServiceProxy.study.ontologyTerm.allDescendants
-        def conceptWrappers = OntologyTermWrapper.wrap(concepts)
+        def conceptWrappers = concepts.collect { new OntologyTermWrapper(it, false) }
         respond wrapConcepts(conceptWrappers)
     }
 
@@ -57,7 +57,8 @@ class ConceptController {
         use (OntologyTermCategory) {
             String key = id.keyFromURLPart studyLoadingServiceProxy.study
             def concept = conceptsResourceService.getByKey(key)
-            respond new OntologyTermWrapper(concept)
+            respond new OntologyTermWrapper(concept,
+                    id == OntologyTermCategory.ROOT_CONCEPT_PATH)
         }
     }
 

--- a/grails-app/controllers/org/transmartproject/rest/HighDimController.groovy
+++ b/grails-app/controllers/org/transmartproject/rest/HighDimController.groovy
@@ -139,7 +139,7 @@ class HighDimController {
         resourceMap.collect {
             HighDimensionDataTypeResource hdr, Collection<Assay> assays ->
             new HighDimSummary(
-                    conceptWrapper: new OntologyTermWrapper(concept),
+                    conceptWrapper: new OntologyTermWrapper(concept, false),
                     name: hdr.dataTypeName,
                     assayCount: assays.size(),
                     supportedProjections: hdr.supportedProjections,

--- a/src/groovy/org/transmartproject/rest/marshallers/ApiOntologyTermType.groovy
+++ b/src/groovy/org/transmartproject/rest/marshallers/ApiOntologyTermType.groovy
@@ -1,0 +1,14 @@
+package org.transmartproject.rest.marshallers
+
+/**
+ * Values for the type key on the onotlogy term response.
+ */
+enum ApiOntologyTermType {
+    STUDY,
+    HIGH_DIMENSIONAL,
+    NUMERIC,
+    CATEGORICAL_OPTION,
+    FOLDER,      // reserved
+    CATEGORICAL, // reserved
+    UNKNOWN,
+}

--- a/src/groovy/org/transmartproject/rest/marshallers/OntologyTermSerializationHelper.groovy
+++ b/src/groovy/org/transmartproject/rest/marshallers/OntologyTermSerializationHelper.groovy
@@ -100,9 +100,10 @@ class OntologyTermSerializationHelper extends AbstractHalOrJsonSerializationHelp
         OntologyTerm term = obj.delegate
         def result =
             [
-                name:     term.name,
-                key:      term.key,
-                fullName: term.fullName,
+                    name:     term.name,
+                    key:      term.key,
+                    fullName: term.fullName,
+                    type:     obj.apiOntologyTermType.name(),
             ]
 
         Map<OntologyTerm, List<OntologyTermTag>> map = tagsResource.getTags([term] as Set, false)

--- a/src/groovy/org/transmartproject/rest/marshallers/OntologyTermWrapper.groovy
+++ b/src/groovy/org/transmartproject/rest/marshallers/OntologyTermWrapper.groovy
@@ -27,25 +27,43 @@ package org.transmartproject.rest.marshallers
 
 import org.transmartproject.core.ontology.OntologyTerm
 
+import static org.transmartproject.core.ontology.OntologyTerm.VisualAttributes.HIGH_DIMENSIONAL
+import static org.transmartproject.core.ontology.OntologyTerm.VisualAttributes.LEAF
+
 /**
  * Wraps an OntologyTerm for serialization.
  * Marshallers/Serializers have a static registry where the class is the key, and transSMART already
  * has its own serializer for OntologyTerm, so we use this class to wrap the OntologyTerm and pick the right Serializer
- * for REST API
+ * for REST API.
+ *
+ * We also use it for some helper methods.
  */
 class OntologyTermWrapper {
 
     OntologyTerm delegate
 
-    OntologyTermWrapper(OntologyTerm term) {
-        this.delegate = term
-    }
+    private boolean root = false
 
-    static List<OntologyTermWrapper> wrap(List<OntologyTerm> source) {
-        source.collect { new OntologyTermWrapper(it) }
+    OntologyTermWrapper(OntologyTerm term, boolean root) {
+        this.delegate = term
+        this.root = root
     }
 
     boolean isHighDim() {
-        OntologyTerm.VisualAttributes.HIGH_DIMENSIONAL in this.delegate.visualAttributes
+        HIGH_DIMENSIONAL in delegate.visualAttributes
+    }
+
+    ApiOntologyTermType getApiOntologyTermType() {
+        if (highDim) {
+            ApiOntologyTermType.HIGH_DIMENSIONAL
+        } else if (root) {
+            ApiOntologyTermType.STUDY
+        } else if (delegate.metadata?.okToUseValues) {
+            ApiOntologyTermType.NUMERIC
+        } else if (LEAF in delegate.visualAttributes) {
+            ApiOntologyTermType.CATEGORICAL_OPTION
+        } else {
+            ApiOntologyTermType.UNKNOWN
+        }
     }
 }

--- a/src/groovy/org/transmartproject/rest/marshallers/StudySerializationHelper.groovy
+++ b/src/groovy/org/transmartproject/rest/marshallers/StudySerializationHelper.groovy
@@ -27,6 +27,9 @@ package org.transmartproject.rest.marshallers
 
 import grails.rest.Link
 import org.transmartproject.core.ontology.Study
+import org.transmartproject.rest.StudyLoadingService
+
+import javax.annotation.Resource
 
 import static grails.rest.render.util.AbstractLinkingRenderer.RELATIONSHIP_SELF
 
@@ -44,9 +47,8 @@ class StudySerializationHelper extends AbstractHalOrJsonSerializationHelper<Stud
 
     @Override
     Map<String, Object> convertToMap(Study study) {
-        def term = new OntologyTermWrapper(study.ontologyTerm)
-            [id: study.id,
-                ontologyTerm: term]
+        def term = new OntologyTermWrapper(study.ontologyTerm, true)
+            [id: study.id, ontologyTerm: term]
     }
 
     @Override

--- a/test/functional/org/transmartproject/rest/ConceptsResourceTests.groovy
+++ b/test/functional/org/transmartproject/rest/ConceptsResourceTests.groovy
@@ -57,6 +57,9 @@ class ConceptsResourceTests extends ResourceTestCase {
     def longConceptKey = "\\\\i2b2 main$longConceptPath"
     def longConceptUrl = '/studies/study_id_2/concepts/long%20path/with%25some%24characters_'
 
+    def sexConceptUrl = '/studies/study_id_2/concepts/sex'
+    def femaleConceptUrl = '/studies/study_id_2/concepts/sex/female'
+
     def study2ConceptListUrl = '/studies/study_id_2/concepts'
 
     def study1RootConceptTags = [
@@ -157,6 +160,40 @@ class ConceptsResourceTests extends ResourceTestCase {
         def result = getAsHal rootConceptUrl
         assertStatus 200
         assertThat result, MetadataTagsMatcher.hasTags(study1RootConceptTags)
+    }
+
+    void testDataTypeStudy() {
+        // unfortunately the test data has no concept with the study
+        // visual attribute. This is detected as a study because the ontology
+        // term is the same as the one studyLoadingService.study.ot returns
+        // See OntologyTermWrapper
+        def result = getAsJson rootConceptUrl
+        assertStatus 200
+        assertThat result, hasEntry('type', 'STUDY')
+    }
+
+    void testDataTypeHighDimensional() {
+        def result = getAsJson conceptUrl //study 1/bar
+        assertStatus 200
+        assertThat result, hasEntry('type', 'HIGH_DIMENSIONAL')
+    }
+
+    void testDataTypeNumeric() {
+        def result = getAsJson longConceptUrl
+        assertStatus 200
+        assertThat result, hasEntry('type', 'NUMERIC')
+    }
+
+    void testDataTypeCategoricalOption() {
+        def result = getAsJson femaleConceptUrl
+        assertStatus 200
+        assertThat result, hasEntry('type', 'CATEGORICAL_OPTION')
+    }
+
+    void testDataTypeUnknown() {
+        def result = getAsJson sexConceptUrl
+        assertStatus 200
+        assertThat result, hasEntry('type', 'UNKNOWN')
     }
 
     private Matcher jsonConceptResponse(String key = conceptKey,


### PR DESCRIPTION
It is not possible (without expensive operations) to distinguish generic folder containers from
containers of categorical options, so UNKNOWN is returned in those
cases. The types FOLDER and CATEGORICAL are nonetheless reserved
for future use.