### PR TITLE
Fix problem with returning empty sets in hal+json.

### DIFF
--- a/grails-app/controllers/org/transmartproject/rest/StudyController.groovy
+++ b/grails-app/controllers/org/transmartproject/rest/StudyController.groovy
@@ -25,9 +25,13 @@
 
 package org.transmartproject.rest
 
-import org.transmartproject.core.ontology.StudiesResource
+import grails.rest.Link
 
 import javax.annotation.Resource
+
+import org.transmartproject.core.ontology.StudiesResource
+import org.transmartproject.core.ontology.Study
+import org.transmartproject.rest.marshallers.ContainerResponseWrapper
 
 class StudyController {
 
@@ -40,7 +44,7 @@ class StudyController {
      *  This will return the list of studies, where each study will be rendered in its short format
     */
     def index() {
-        respond studiesResourceService.studySet
+        respond wrapStudies(studiesResourceService.studySet)
     }
 
     /** GET request on /studies/${id}
@@ -51,4 +55,18 @@ class StudyController {
     def show(String id) {
         respond studiesResourceService.getStudyById(id)
     }
+    
+    private def wrapStudies(Object source) {
+        
+        new ContainerResponseWrapper(
+                container: source,
+                componentType: Study,
+                links: [
+                        new Link(grails.rest.render.util.AbstractLinkingRenderer.RELATIONSHIP_SELF,
+                                "/studies"
+                        )
+                ]
+        )
+    }
+    
 }

--- a/grails-app/controllers/org/transmartproject/rest/StudyController.groovy
+++ b/grails-app/controllers/org/transmartproject/rest/StudyController.groovy
@@ -26,6 +26,7 @@
 package org.transmartproject.rest
 
 import grails.rest.Link
+import grails.rest.render.util.AbstractLinkingRenderer
 
 import javax.annotation.Resource
 
@@ -56,16 +57,12 @@ class StudyController {
         respond studiesResourceService.getStudyById(id)
     }
     
-    private def wrapStudies(Object source) {
-        
-        new ContainerResponseWrapper(
-                container: source,
-                componentType: Study,
-                links: [
-                        new Link(grails.rest.render.util.AbstractLinkingRenderer.RELATIONSHIP_SELF,
-                                "/studies"
-                        )
-                ]
+    private wrapStudies(Object source) {
+        new ContainerResponseWrapper
+        (
+            container: source,
+            componentType: Study,
+            links: [ new Link(AbstractLinkingRenderer.RELATIONSHIP_SELF, "/studies") ]
         )
     }
     

--- a/test/functional/org/transmartproject/rest/StudiesResourceTests.groovy
+++ b/test/functional/org/transmartproject/rest/StudiesResourceTests.groovy
@@ -27,7 +27,6 @@ package org.transmartproject.rest
 
 import static org.hamcrest.MatcherAssert.assertThat
 import static org.hamcrest.Matchers.*
-import groovy.json.JsonBuilder;
 
 class StudiesResourceTests extends ResourceTestCase {
 

--- a/test/functional/org/transmartproject/rest/StudiesResourceTests.groovy
+++ b/test/functional/org/transmartproject/rest/StudiesResourceTests.groovy
@@ -27,6 +27,7 @@ package org.transmartproject.rest
 
 import static org.hamcrest.MatcherAssert.assertThat
 import static org.hamcrest.Matchers.*
+import groovy.json.JsonBuilder;
 
 class StudiesResourceTests extends ResourceTestCase {
 
@@ -37,7 +38,7 @@ class StudiesResourceTests extends ResourceTestCase {
         get("${baseURL}studies")
         assertStatus 200
 
-        assertThat JSON, contains(
+        assertThat JSON, hasEntry(is('studies'), contains(
                 allOf(
                         hasEntry('id', 'STUDY_ID_1'),
                         hasEntry(is('ontologyTerm'), allOf(
@@ -62,7 +63,50 @@ class StudiesResourceTests extends ResourceTestCase {
                                 hasEntry('key', '\\\\i2b2 main\\foo\\study3\\'),
                         ))
                 )
-        )
+        ))
+    }
+
+    void testListAllStudiesAsHal() {
+        def result = getAsHal("${baseURL}studies")
+        
+        //log.info "testListAllStudiesAsHal:\n" + result.toString(2) 
+        
+        assertStatus 200
+
+        assertThat result, halIndexResponse('/studies', ['studies': 
+            contains(
+                allOf(
+                        hasEntry('id', 'STUDY_ID_1'),
+                        halIndexResponse('/studies/study_id_1', ['ontologyTerm':
+                            allOf(
+                                hasEntry('name', 'study1'),
+                                hasEntry('fullName', '\\foo\\study1\\'),
+                                hasEntry('key', '\\\\i2b2 main\\foo\\study1\\'),
+                            )
+                        ])
+                ),
+                allOf(
+                        hasEntry('id', 'STUDY_ID_2'),
+                        halIndexResponse('/studies/study_id_2', ['ontologyTerm':
+                            allOf(
+                                hasEntry('name', 'study2'),
+                                hasEntry('fullName', '\\foo\\study2\\'),
+                                hasEntry('key', '\\\\i2b2 main\\foo\\study2\\'),
+                            )
+                        ])
+                ),
+                allOf(
+                        hasEntry('id', 'STUDY_ID_3'),
+                        halIndexResponse('/studies/study_id_3', ['ontologyTerm':
+                            allOf(
+                                hasEntry('name', 'study3'),
+                                hasEntry('fullName', '\\foo\\study3\\'),
+                                hasEntry('key', '\\\\i2b2 main\\foo\\study3\\'),
+                            )
+                        ])
+                )
+            )
+        ])
     }
 
     void testGetStudy() {
@@ -80,6 +124,25 @@ class StudiesResourceTests extends ResourceTestCase {
         )
     }
 
+    void testGetStudyAsHal() {
+        def studyId = 'STUDY_ID_1'
+        def result = getAsHal("${baseURL}studies/${studyId}")
+        assertStatus 200
+
+        //log.info "testGetStudyAsHal:\n" + result.toString(2)
+        
+        assertThat result, allOf(
+            hasEntry('id', 'STUDY_ID_1'),
+            halIndexResponse("/studies/${studyId}".toLowerCase(), [
+                'ontologyTerm': allOf(
+                    hasEntry('name', 'study1'),
+                    hasEntry('fullName', '\\foo\\study1\\'),
+                    hasEntry('key', '\\\\i2b2 main\\foo\\study1\\'),
+                )
+            ])
+        )
+    }
+    
     void testListStudiesChildLink() {
         def path = "_embedded.studies[0].$childLinkHrefPath"
         def result = getAsHal '/studies'


### PR DESCRIPTION
When fetching the list of studies with HTTP header
'Accept: application/hal+json', the application returned code 
406 'Not acceptable' if the set of studies was empty.