### PR TITLE
Export 'double' and other primitive typed highdim data as numbers instead of strings

### DIFF
--- a/src/groovy/org/transmartproject/rest/protobuf/HighDimBuilder.groovy
+++ b/src/groovy/org/transmartproject/rest/protobuf/HighDimBuilder.groovy
@@ -175,8 +175,7 @@ class HighDimBuilder {
     }
 
     private static Class decideColumnValueType(Class originalClass) {
-        if (originalClass in [double, float, long, int, short, byte] ||
-                Number.isAssignableFrom(originalClass)) {
+        if (originalClass in [double, float, long, int, short, byte] || originalClass in Number) {
             return Double
         } else {
             // Anything that is not a number is serialized as string

--- a/src/groovy/org/transmartproject/rest/protobuf/HighDimBuilder.groovy
+++ b/src/groovy/org/transmartproject/rest/protobuf/HighDimBuilder.groovy
@@ -175,7 +175,12 @@ class HighDimBuilder {
     }
 
     private static Class decideColumnValueType(Class originalClass) {
-        Number.isAssignableFrom(originalClass) ? Double : String
+        if (originalClass in [double, float, long, int, short, byte] ||
+                Number.isAssignableFrom(originalClass)) {
+            return Double
+        } else {
+            return String
+        }
     }
 
     private Row createRow(DataRow<AssayColumn, ?> inputRow) {

--- a/src/groovy/org/transmartproject/rest/protobuf/HighDimBuilder.groovy
+++ b/src/groovy/org/transmartproject/rest/protobuf/HighDimBuilder.groovy
@@ -179,6 +179,7 @@ class HighDimBuilder {
                 Number.isAssignableFrom(originalClass)) {
             return Double
         } else {
+            // Anything that is not a number is serialized as string
             return String
         }
     }

--- a/test/unit/org/transmartproject/rest/protobug/HighDimBuilderTests.groovy
+++ b/test/unit/org/transmartproject/rest/protobug/HighDimBuilderTests.groovy
@@ -118,6 +118,23 @@ class HighDimBuilderTests {
                         hasProperty('stringValueList', contains('text1', 'text2')))))
     }
 
+    @Test
+    void "test column type choice."() {
+        assertThat HighDimBuilder.decideColumnValueType(String), sameInstance(String)
+        assertThat HighDimBuilder.decideColumnValueType(Object), sameInstance(String)
+        assertThat HighDimBuilder.decideColumnValueType(HighDimBuilder), sameInstance(String)
+
+        assertThat HighDimBuilder.decideColumnValueType(double), sameInstance(Double)
+        assertThat HighDimBuilder.decideColumnValueType(byte), sameInstance(Double)
+        assertThat HighDimBuilder.decideColumnValueType(int), sameInstance(Double)
+        assertThat HighDimBuilder.decideColumnValueType(float), sameInstance(Double)
+        assertThat HighDimBuilder.decideColumnValueType(Double), sameInstance(Double)
+        assertThat HighDimBuilder.decideColumnValueType(Float), sameInstance(Double)
+        assertThat HighDimBuilder.decideColumnValueType(BigDecimal), sameInstance(Double)
+        assertThat HighDimBuilder.decideColumnValueType(Number), sameInstance(Double)
+        assertThat HighDimBuilder.decideColumnValueType(BigInteger), sameInstance(Double)
+    }
+
     class TestProjection implements MultiValueProjection, Projection {
         Map<String, Class> dataProperties
 


### PR DESCRIPTION
The REST api would export double[] type data as strings, because Number.isAssignableFrom(double) is false